### PR TITLE
benchmark: review comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,9 @@ publish-docs:
 test :
 	dune runtest
 
-# Echo is disabled as the benchmarks results are printed on stdout.
-# '@bench' exit status is not checked as it's very likely to fail due to
-# needing promotion rather than because it really failed.
 .PHONY : bench
 bench:
-	-@dune build @bench
-	@dune promote driver-benchmarks.json
-	@cat driver-benchmarks.json
+	@dune build @bench
 
 .PHONY : coverage
 coverage :

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -789,11 +789,11 @@ If needed, the list of commands executed so far can be shown by de-commenting th
 # (* List.iter print_cmd (List.rev !commands);; *)
 ]}
 
-Print the slowest commands for each subcommands:
+If needed, the list of the slowest commands for each subcommands can be shown by de-commenting this block:
 (for the record, these commands are run from directory `_build/default/doc`)
 
 {[
-# List.iter print_cmd (k_longest_commands "compile" 5)
+# (* List.iter print_cmd (k_longest_commands "compile" 5) *)
 # (* List.iter print_cmd (k_longest_commands "link" 5) *)
 # (* List.iter print_cmd (k_longest_commands "html-generate" 5) *)
 ]}

--- a/doc/dune
+++ b/doc/dune
@@ -31,15 +31,12 @@
   (> %{ocaml_version} 4.11))
  (deps
   (package odoc)
+  (universe) ; Benchmark depends on the running programs in the background
   (glob_files *.mld)
   (glob_files library_mlds/*)
   (glob_files examples/*.ml*))
  (action
-  (progn
-   ; Make sure the benchmark result is created as Dune would not show the diff
-   ; if the script failed before creating it.
-   (write-file driver-benchmarks.json "")
-   (run ocaml-mdx-test --force-output %{dep:driver.mld}))))
+   (run ocaml-mdx-test --force-output %{dep:driver.mld})))
 
 (rule
  (alias docgen)

--- a/doc/dune
+++ b/doc/dune
@@ -31,7 +31,7 @@
   (> %{ocaml_version} 4.11))
  (deps
   (package odoc)
-  (universe) ; Benchmark depends on the running programs in the background
+  (universe) ; Benchmark depends on the running time of odoc commands
   (glob_files *.mld)
   (glob_files library_mlds/*)
   (glob_files examples/*.ml*))

--- a/dune
+++ b/dune
@@ -12,4 +12,4 @@
 (rule
  (alias bench)
  (action
-  (diff driver-benchmarks.json doc/driver-benchmarks.json)))
+  (cat doc/driver-benchmarks.json)))


### PR DESCRIPTION
- Make multiple runs of benchmark actually run.
- Fix non-existent driver-benchmarks.json by adopting a simpler approach: instead of outputing in a file, then promoting, then running `cat`, we just output in the standard output.